### PR TITLE
Fix `yolo` FormatSpec

### DIFF
--- a/optical/converter/yolo.py
+++ b/optical/converter/yolo.py
@@ -184,7 +184,7 @@ class Yolo(FormatSpec):
 
             categories = label_desc["names"]
             label_map = dict(zip(range(len(categories)), categories))
-        except:
+        except FileNotFoundError:
             label_map = dict()
             warnings.warn(f"No `dataset.yaml` file found in {self._annotation_dir}")
 


### PR DESCRIPTION
## What does this PR fix?

There were many bugs in the yolo FormatSpec including:

- it was only reading the first line of the text file [fixed]
- the `x_min` and `x_max` was wrongly populated as `x_center` and `y_center` [fixed]
- there was no support for flat directory structure [fixed]
- the `master_df` was missing the `image_path` column [fixed]