### PR TITLE
Feature/add simple json

### DIFF
--- a/optical/converter/__init__.py
+++ b/optical/converter/__init__.py
@@ -101,6 +101,7 @@ class Annotation:
         image_dir: Optional[Union[str, os.PathLike]] = None,
         split: Optional[str] = None,
         img_size: Optional[int] = 512,
+        **kwargs,
     ):
         if image_dir is None:
             random_split = random.choice(list(self.formatspec.master_df.split.unique()))
@@ -115,4 +116,4 @@ class Annotation:
             else:
                 image_dir = get_image_dir(self.root)
         image_dir = Path(image_dir)
-        return Visualizer(image_dir, self.formatspec.master_df, split, img_size)
+        return Visualizer(image_dir, self.formatspec.master_df, split, img_size, **kwargs)

--- a/optical/converter/__init__.py
+++ b/optical/converter/__init__.py
@@ -18,6 +18,7 @@ from .pascal import Pascal
 from .sagemaker import SageMaker
 from .createml import CreateML
 from .tfrecord import Tfrecord
+from .simple_json import SimpleJson
 from ..visualizer.visualizer import Visualizer
 from .utils import get_image_dir, ifnone
 
@@ -35,6 +36,7 @@ SUPPORTED_FORMATS = {
     "pascal": Pascal,
     "tfrecord": Tfrecord,
     "createml": CreateML,
+    "simple_json": SimpleJson,
 }
 
 

--- a/optical/converter/simple_json.py
+++ b/optical/converter/simple_json.py
@@ -7,7 +7,6 @@ Created: Monday, 29th March 2021
 
 import json
 import os
-import warnings
 from pathlib import Path
 from typing import Union
 
@@ -62,24 +61,10 @@ class SimpleJson(FormatSpec):
         self._image_dir = get_image_dir(root)
         self._annotation_dir = get_annotation_dir(root)
         self._has_image_split = False
-        self.format = "simple_json"
         assert exists(self._image_dir), "root is missing `images` directory."
         assert exists(self._annotation_dir), "root is missing `annotations` directory."
-        self._splits = self._find_splits()
+        self._find_splits()
         self._resolve_dataframe()
-
-    def _find_splits(self):
-        """find the splits in the dataset, will ignore splits for which no annotation is found"""
-        im_splits = [x.name for x in Path(self._image_dir).iterdir() if x.is_dir()]
-        ann_splits = [x.stem for x in Path(self._annotation_dir).glob("*.json")]
-
-        if im_splits:
-            self._has_image_split = True
-
-        no_anns = set(im_splits).difference(ann_splits)
-        if no_anns:
-            warnings.warn(f"no annotation found for {', '.join(list(no_anns))}")
-        return ann_splits
 
     def _resolve_dataframe(self):
         columns = [

--- a/optical/converter/utils.py
+++ b/optical/converter/utils.py
@@ -244,7 +244,14 @@ def get_id_to_class_map(df: pd.DataFrame):
 def find_splits(image_dir: Union[str, os.PathLike], annotation_dir: Union[str, os.PathLike], format: str):
     """find the splits in the dataset, will ignore splits for which no annotation is found"""
 
-    exts = {"coco": "json", "pascal": "xml", "yolo": "txt", "sagemaker": "manifest", "createml": "json"}
+    exts = {
+        "coco": "json",
+        "pascal": "xml",
+        "yolo": "txt",
+        "sagemaker": "manifest",
+        "createml": "json",
+        "simple_json": "json",
+    }
 
     ext = exts[format]
 

--- a/optical/visualizer/utils.py
+++ b/optical/visualizer/utils.py
@@ -136,6 +136,9 @@ def plot_boxes(
     """
     draw_img = np.array(img)
     for i, box in enumerate(bboxes):
+        threshold = kwargs.get("threshold", None)
+        if threshold is not None and scores[i] < threshold:
+            continue
         bbox = list(map(lambda x: max(0, int(x)), box[:-1]))
         if not isinstance(box[-1], str):
             category = class_map.get(int(box[-1]), str(int(box[-1])))

--- a/optical/visualizer/visualizer.py
+++ b/optical/visualizer/visualizer.py
@@ -46,6 +46,7 @@ class Visualizer:
         dataframe: pd.DataFrame,
         split: Optional[str] = None,
         img_size: int = 512,
+        **kwargs,
     ):
         # Check images dir and dataframe
         assert check_num_imgs(images_dir), f"No images found in {(images_dir)}, Please check."
@@ -59,8 +60,12 @@ class Visualizer:
         self.images_dir = images_dir
         self.resize = (img_size, img_size)
         self.original_df = dataframe
+        if kwargs.get("threshold", None) is not None and "score" in self.original_df.columns:
+            threshold = kwargs.get("threshold")
+            assert threshold > 0 and threshold <= 1, f"Threshold shoule be between [0.,1.],but received {threshold}"
+            self.original_df = self.original_df.query("score >= @threshold").copy()
         if split is not None:
-            self.original_df = dataframe.query("split == @split").copy()
+            self.original_df = self.original_df.query("split == @split").copy()
         if self.original_df.shape[0] < 1:
             warnings.warn(
                 f"There are no images to be visualized in {split}. Please check the correct split and dataframe."
@@ -296,8 +301,8 @@ class Visualizer:
                 )
                 image_names.append(img_name)
                 drawn_imgs.append(drawn_img)
-            except Exception:
-                warnings.warn(f"Could not plot bounding boxes for {img_name}")
+            except Exception as e:
+                warnings.warn(f"Could not plot bounding boxes for {img_name}: {str(e)}")
                 continue
 
         return drawn_imgs, image_names

--- a/optical/visualizer/visualizer.py
+++ b/optical/visualizer/visualizer.py
@@ -59,13 +59,13 @@ class Visualizer:
         # Initialization
         self.images_dir = images_dir
         self.resize = (img_size, img_size)
-        self.original_df = dataframe
+        self.original_df = dataframe.copy()
         if kwargs.get("threshold", None) is not None and "score" in self.original_df.columns:
             threshold = kwargs.get("threshold")
             assert threshold > 0 and threshold <= 1, f"Threshold shoule be between [0.,1.],but received {threshold}"
-            self.original_df = self.original_df.query("score >= @threshold").copy()
+            self.original_df = self.original_df.query("score >= @threshold")
         if split is not None:
-            self.original_df = self.original_df.query("split == @split").copy()
+            self.original_df = self.original_df.query("split == @split")
         if self.original_df.shape[0] < 1:
             warnings.warn(
                 f"There are no images to be visualized in {split}. Please check the correct split and dataframe."


### PR DESCRIPTION
* Add support for visualizing predictions from a model in a defined format.
An example of the format is:
```
[
{"image_name1":[{"bbox":[xmin,ymin,xmax,ymax],"classname":cls1,"confidence":0.8}],
{"image_name2":[{"bbox":[xmin,ymin,xmax,ymax],"classname":cls2,"confidence":0.35},
                {"bbox":[xmin,ymin,xmax,ymax],"classname":cls1,"confidence":0.45},
                {...}
                ],
{...},
{...}
]
```
Root directory structure while loading the annotation is similar to `coco` format
```
 root
 ├── images
  │  ├── prediction1
  │   │   ├── 1.jpg
  │   │   ├── 2.jpg
  │   │   │   ...
  │   │   └── n.jpg
  │   ├── prediction2 (...)
  │   └── prediction3 (...)
  │
  └── annotations
      ├── prediction1.json
      ├── prediction2.json
      └── prediction3.json
or
  root
  ├── images
  │   ├── 1.jpg
  │   ├── 2.jpg
  │   │   ...
  │   └── n.jpg
  │
  └── annotations
      └── predictions.json
```