### PR TITLE
refactor and fix find_splits

### DIFF
--- a/optical/converter/__init__.py
+++ b/optical/converter/__init__.py
@@ -49,6 +49,16 @@ class Annotation:
         self.format = format
         self.formatspec = SUPPORTED_FORMATS[format.lower()](root)
 
+    def __str__(self):
+        return self.formatspec.__str__()
+
+    def __repr__(self):
+        return self.formatspec.__repr__()
+
+    @property
+    def splits(self):
+        return self.formatspec.splits
+
     @property
     def label_df(self):
         return self.formatspec.master_df

--- a/optical/converter/base.py
+++ b/optical/converter/base.py
@@ -23,7 +23,7 @@ from .converter import (
     convert_tfrecord,
     convert_createml,
 )
-from .utils import filter_split_category, ifnone
+from .utils import filter_split_category, ifnone, find_splits
 
 pd.options.mode.chained_assignment = None
 _TF_INSTALLED = True
@@ -47,12 +47,32 @@ class FormatSpec:
         self._has_image_split = has_split
         self.master_df = df
         self.format = format
+        self._splits = None
 
     # @abstractmethod
     # removing absract class as it cannot be instantiated from within
     # as required for split
     def _resolve_dataframe(self):
         pass
+
+    def __str__(self):
+        return f"{self.format.upper()}[root:{self.root}, splits:[{', '.join(self.splits)}]]"
+
+    def __repr__(self):
+        return self.format
+
+    @property
+    def format(self):
+        return self.__module__.split(".")[-1]
+
+    @property
+    def splits(self):
+        return self._splits
+
+    def _find_splits(self):
+        splits, has_image_split = find_splits(self._image_dir, self._annotation_dir, self.format)
+        self._has_image_split = has_image_split
+        self._splits = splits
 
     def bbox_stats(self, split: Optional[str] = None, category: Optional[str] = None) -> pd.DataFrame:
         """computes bbox descriptive stats e.g., mean, std etc.

--- a/optical/converter/coco.py
+++ b/optical/converter/coco.py
@@ -61,24 +61,10 @@ class Coco(FormatSpec):
         self._image_dir = get_image_dir(root)
         self._annotation_dir = get_annotation_dir(root)
         self._has_image_split = False
-        self.format = "coco"
         assert exists(self._image_dir), "root is missing `images` directory."
         assert exists(self._annotation_dir), "root is missing `annotations` directory."
-        self._splits = self._find_splits()
+        self._find_splits()
         self._resolve_dataframe()
-
-    def _find_splits(self):
-        """find the splits in the dataset, will ignore splits for which no annotation is found"""
-        im_splits = [x.name for x in Path(self._image_dir).iterdir() if x.is_dir()]
-        ann_splits = [x.stem for x in Path(self._annotation_dir).glob("*.json")]
-
-        if im_splits:
-            self._has_image_split = True
-
-        no_anns = set(im_splits).difference(ann_splits)
-        if no_anns:
-            warnings.warn(f"no annotation found for {', '.join(list(no_anns))}")
-        return ann_splits
 
     def _get_class_map(self, categories: List):
         """map from category id to category name"""

--- a/optical/converter/createml.py
+++ b/optical/converter/createml.py
@@ -7,7 +7,6 @@ Created: Wednesday, 31st March 2021
 import json
 import os
 import warnings
-from pathlib import Path
 from typing import Union
 
 import imagesize
@@ -61,26 +60,10 @@ class CreateML(FormatSpec):
         self._image_dir = get_image_dir(root)
         self._annotation_dir = get_annotation_dir(root)
         self._has_image_split = False
-        self.format = "createml"
         assert exists(self._image_dir), "root is missing `images` directory."
         assert exists(self._annotation_dir), "root is missing `annotations` directory."
-        self._splits = self._find_splits()
+        self._find_splits()
         self._resolve_dataframe()
-
-    def _find_splits(self):
-        im_splits = [x.name for x in Path(self._image_dir).iterdir() if x.is_dir()]
-        ann_splits = [x.stem for x in Path(self._annotation_dir).glob("*.json")]
-
-        if im_splits:
-            self._has_image_split = True
-
-        if not len(ann_splits):
-            warnings.warn(f"no annotation file found inside {self._annotation_dir}")
-
-        no_anns = set(im_splits).difference(ann_splits)
-        if no_anns:
-            warnings.warn(f"no annotation found for {', '.join(list(no_anns))}")
-        return ann_splits
 
     def _resolve_dataframe(self):
         master_data = {

--- a/optical/converter/pascal.py
+++ b/optical/converter/pascal.py
@@ -68,10 +68,9 @@ class Pascal(FormatSpec):
         self._image_dir = get_image_dir(root)
         self._annotation_dir = get_annotation_dir(root)
         self._has_image_split = False
-        self.format = "pascal"
         assert exists(self._image_dir), "root is missing `images` directory."
         assert exists(self._annotation_dir), "root is missing `annotations` directory."
-        self._splits = self._find_splits()
+        self._find_splits()
         self._resolve_dataframe()
 
     def _resolve_dataframe(self):

--- a/optical/converter/pascal.py
+++ b/optical/converter/pascal.py
@@ -6,8 +6,7 @@ Created: Wednesday, 31st March 2021
 
 import os
 
-import warnings
-from pathlib import Path
+
 from typing import Union
 import numpy as np
 
@@ -74,18 +73,6 @@ class Pascal(FormatSpec):
         assert exists(self._annotation_dir), "root is missing `annotations` directory."
         self._splits = self._find_splits()
         self._resolve_dataframe()
-
-    def _find_splits(self):
-        im_splits = [x.name for x in Path(self._image_dir).iterdir() if x.is_dir()]
-        ann_splits = [x.name for x in Path(self._annotation_dir).iterdir() if x.is_dir()]
-
-        if im_splits:
-            self._has_image_split = True
-
-        no_anns = set(im_splits).difference(ann_splits)
-        if no_anns:
-            warnings.warn(f"no annotation found for {','.join(list(no_anns))}")
-        return ann_splits
 
     def _resolve_dataframe(self):
         if self._has_image_split:

--- a/optical/converter/sagemaker.py
+++ b/optical/converter/sagemaker.py
@@ -6,8 +6,6 @@ Created: Wednesday, 31st March 2021
 
 import json
 import os
-import warnings
-from pathlib import Path
 from typing import Union
 
 import pandas as pd
@@ -60,26 +58,10 @@ class SageMaker(FormatSpec):
         self._image_dir = get_image_dir(root)
         self._annotation_dir = get_annotation_dir(root)
         self._has_image_split = False
-        self.format = "sagemaker"
         assert exists(self._image_dir), "root is missing `images` directory."
         assert exists(self._annotation_dir), "root is missing `annotations` directory."
-        self._splits = self._find_splits()
+        self._find_splits()
         self._resolve_dataframe()
-
-    def _find_splits(self):
-        im_splits = [x.name for x in Path(self._image_dir).iterdir() if x.is_dir()]
-        ann_splits = [x.stem for x in Path(self._annotation_dir).glob("*.manifest")]
-
-        if im_splits:
-            self._has_image_split = True
-
-        if not len(ann_splits):
-            warnings.warn(f"no annotation file found inside {self._annotation_dir}")
-
-        no_anns = set(im_splits).difference(ann_splits)
-        if no_anns:
-            warnings.warn(f"no annotation found for {', '.join(list(no_anns))}")
-        return ann_splits
 
     def _resolve_dataframe(self):
         master_data = {

--- a/optical/converter/utils.py
+++ b/optical/converter/utils.py
@@ -252,8 +252,8 @@ def find_splits(image_dir: Union[str, os.PathLike], annotation_dir: Union[str, o
 
     if format in ("yolo", "pascal"):
         ann_splits = [x.name for x in Path(annotation_dir).iterdir() if x.is_dir()]
-        if not ann_splits:
 
+        if not ann_splits:
             files = list(Path(annotation_dir).glob(f"*.{ext}"))
             if len(files):
                 ann_splits = ["main"]

--- a/optical/converter/utils.py
+++ b/optical/converter/utils.py
@@ -241,6 +241,35 @@ def get_id_to_class_map(df: pd.DataFrame):
     return set_df.set_index("class_id")["category"].to_dict()
 
 
+def find_splits(image_dir: Union[str, os.PathLike], annotation_dir: Union[str, os.PathLike], format: str):
+    """find the splits in the dataset, will ignore splits for which no annotation is found"""
+
+    exts = {"coco": "json", "pascal": "xml", "yolo": "txt", "sagemaker": "manifest", "createml": "json"}
+
+    ext = exts[format]
+
+    im_splits = [x.name for x in Path(image_dir).iterdir() if x.is_dir() and not x.name.startswith(".")]
+
+    if format in ("yolo", "pascal"):
+        ann_splits = [x.name for x in Path(annotation_dir).iterdir() if x.is_dir()]
+        if not ann_splits:
+
+            files = list(Path(annotation_dir).glob(f"*.{ext}"))
+            if len(files):
+                ann_splits = ["main"]
+            else:
+                raise ValueError("No annotation found. Please check the directory specified.")
+
+    else:
+        ann_splits = [x.stem for x in Path(annotation_dir).glob(f"*.{ext}")]
+
+    no_anns = set(im_splits).difference(ann_splits)
+    if no_anns:
+        warnings.warn(f"no annotation found for {', '.join(list(no_anns))}")
+
+    return ann_splits, len(im_splits) > 0
+
+
 def _tf_parse_example(example):
     """parse tf examples"""
     features = {

--- a/optical/converter/yolo.py
+++ b/optical/converter/yolo.py
@@ -75,25 +75,8 @@ class Yolo(FormatSpec):
         self._has_image_split = False
         assert exists(self._image_dir), "root is missing 'images' directory."
         assert exists(self._annotation_dir), "root is missing 'annotations' directory."
-        self._splits = self._find_splits()
+        self._find_splits()
         self._resolve_dataframe()
-
-    def _find_splits(self):
-        im_splits = [x.name for x in Path(self._image_dir).iterdir() if x.is_dir()]
-        ann_splits = [x.name for x in Path(self._annotation_dir).iterdir() if x.is_dir()]
-
-        if not ann_splits:
-            txts = list(Path(self._annotation_dir).glob("*.txt"))
-            if len(txts):
-                return "main"
-
-        if im_splits:
-            self._has_image_split = True
-
-        no_anns = set(im_splits).difference(ann_splits)
-        if no_anns:
-            warnings.warn(f"no annotation found for {','.join(list(no_anns))}")
-        return ann_splits
 
     def _resolve_dataframe(self):
 


### PR DESCRIPTION
## What's included in this PR?

1. universal (almost) `find_splits` across all formats in `converter.utils.`
2. move `_find_splits` to  the base `FormatSpec` class (for formats which requires separate handling it can still be overwritten e.g., for `tfrecord`)
3. make `format` and `split` properties rather than attributes
4. define `__str__` and `__repr__` for  `FormatSpec`
5. fix the logic for `find_split` if a hidden directory is present under `images` directory

## Purpose:
`find_splits` is at the heart of of the `FormatSpec`s .It is becoming extremely hard to keep them consistent across format unless we introduce some standardization.