### PR TITLE
fix createml output directory

### DIFF
--- a/optical/converter/coco.py
+++ b/optical/converter/coco.py
@@ -103,6 +103,10 @@ class Coco(FormatSpec):
             annots_df.drop(["id", "image_id"], axis=1, inplace=True)
             annots_df.rename(columns={"file_name": "image_id"}, inplace=True)
             annots_df["split"] = split
+            split_dir = split if self._has_image_split else ""
+            annots_df["image_path"] = annots_df["image_id"].map(
+                lambda x: self.root.joinpath("images").joinpath(split_dir).joinpath(x)
+            )
 
             if len(annots_df[pd.isnull(annots_df.image_id)]) > 0:
                 warnings.warn(
@@ -112,10 +116,6 @@ class Coco(FormatSpec):
                 )
 
             master_df = pd.concat([master_df, annots_df], ignore_index=True)
-            split_dir = split if self._has_image_split else ""
-            master_df["image_path"] = master_df["image_id"].map(
-                lambda x: self.root.joinpath("images").joinpath(split_dir).joinpath(x)
-            )
 
         master_df = master_df[pd.notnull(master_df.image_id)]
         for col in ["x_min", "y_min", "width", "height"]:

--- a/optical/converter/converter.py
+++ b/optical/converter/converter.py
@@ -407,8 +407,8 @@ def convert_createml(
 
     splits = df.split.unique().tolist()
     for split in splits:
-        output_subdir = output_labeldir if split == "main" else output_labeldir / split
-        output_subdir.mkdir(parents=True, exist_ok=True)
+        # output_subdir = output_labeldir if split == "main" else output_labeldir / split
+        # output_subdir.mkdir(parents=True, exist_ok=True)
 
         split_df = df.query("split == @split").copy()
         # drop images missing width or height information
@@ -432,7 +432,7 @@ def convert_createml(
             file_result["annotations"] = list(map(_make_createml_annotation_data, records))
             createml_data.append(file_result)
 
-        file_path = output_subdir / f"{split}.json"
+        file_path = output_labeldir / f"{split}.json"
         write_json(createml_data, file_path)
 
         if copy_images:

--- a/optical/converter/converter.py
+++ b/optical/converter/converter.py
@@ -102,7 +102,7 @@ def convert_yolo(
     dataset = dict()
 
     for split in splits:
-        output_subdir = output_labeldir / split
+        output_subdir = output_labeldir / split if split != "main" else output_labeldir
         output_subdir.mkdir(parents=True, exist_ok=True)
 
         split_df = df.query("split == @split").copy()
@@ -343,11 +343,11 @@ def convert_sagemaker(
 
     splits = df.split.unique().tolist()
     for split in splits:
-        if split == "main":
-            output_subdir = output_labeldir
-        else:
-            output_subdir = output_labeldir / split
-        output_subdir.mkdir(parents=True, exist_ok=True)
+        # if split == "main":
+        #     output_subdir = output_labeldir
+        # else:
+        #     output_subdir = output_labeldir / split
+        # output_subdir.mkdir(parents=True, exist_ok=True)
         split_df = df.query("split == @split").copy()
 
         # drop images missing width or height information
@@ -363,7 +363,7 @@ def convert_sagemaker(
         id_to_class_map = get_id_to_class_map(split_df)
         grouped_split_df = split_df.groupby(["image_id", "image_width", "image_height"])
 
-        with open(output_subdir / f"{split}.manifest", "w") as f:
+        with open(output_labeldir / f"{split}.manifest", "w") as f:
             for image_info, grouped_info in tqdm(
                 grouped_split_df, total=grouped_split_df.ngroups, desc=f"split: {split}"
             ):
@@ -472,7 +472,7 @@ def convert_pascal(
     splits = df.split.unique().tolist()
 
     for split in splits:
-        output_subdir = output_labeldir / split
+        output_subdir = output_labeldir / split if split != "main" else output_labeldir
         output_subdir.mkdir(parents=True, exist_ok=True)
         split_df = df.query("split == @split")
         images = split_df["image_id"].unique()

--- a/optical/converter/converter.py
+++ b/optical/converter/converter.py
@@ -102,7 +102,7 @@ def convert_yolo(
     dataset = dict()
 
     for split in splits:
-        output_subdir = output_labeldir / split if split != "main" else output_labeldir
+        output_subdir = output_labeldir / split if len(splits) > 1 else output_labeldir
         output_subdir.mkdir(parents=True, exist_ok=True)
 
         split_df = df.query("split == @split").copy()
@@ -472,7 +472,7 @@ def convert_pascal(
     splits = df.split.unique().tolist()
 
     for split in splits:
-        output_subdir = output_labeldir / split if split != "main" else output_labeldir
+        output_subdir = output_labeldir / split if len(splits) > 1 else output_labeldir
         output_subdir.mkdir(parents=True, exist_ok=True)
         split_df = df.query("split == @split")
         images = split_df["image_id"].unique()


### PR DESCRIPTION
For the consolidated format e.g., coco, sagemaker, createml - we do not need a train/test/val directory under annotation when exporting - we should just save the consolidated annotations as `annotations/{split}.{ext}`.

### Update
- When exporting to individual formats (e.g., `yolo`, `pascal`) - if there is only one split - we shouldn't create an additional folder inside `annotations`. Fixed the same for `yolo`, `pascal`. 
- fix `sagemaker` export on the same line as `createml`
- fix a bug with coco `image_path` in `_resolve_dataframe`