### PR TITLE
Speedup loading large yolo datasets.

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx==3.5.3
-sphinx-panels==0.5.2
+sphinx==4.5.0
+sphinx-panels==0.6.0
 sphinx-rtd-theme==0.5.1
 docutils==0.16.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,15 +12,17 @@
 #
 import os
 import sys
+import datetime
 
 # import sphinx_rtd_theme
 
 sys.path.insert(0, os.path.abspath("../.."))
+curr_year = datetime.date.today().year
 
 # -- Project information -----------------------------------------------------
 
 project = "optical"
-copyright = "2021, HashTagML"
+copyright = "2021-{curr_year}, HashTagML"
 author = "HashTagML"
 
 # The full version, including alpha/beta/rc tags

--- a/optical/converter/utils.py
+++ b/optical/converter/utils.py
@@ -17,6 +17,7 @@ from lxml import etree as xml
 from PIL import Image
 import xml.etree.ElementTree as ET
 
+NUM_THREADS = os.cpu_count() // 2
 _TF_INSTALLED = True
 try:
     import tensorflow as tf

--- a/optical/converter/yolo.py
+++ b/optical/converter/yolo.py
@@ -8,15 +8,18 @@ Created: Monday, 29th March 2021
 import os
 import warnings
 from pathlib import Path
-from typing import Union
+from typing import Dict, Union
 
 import imagesize
-import yaml
 import numpy as np
 import pandas as pd
+import yaml
+from tqdm.auto import tqdm
+from joblib import Parallel, delayed
+from functools import partial
 
 from .base import FormatSpec
-from .utils import exists, get_image_dir, get_annotation_dir
+from .utils import exists, get_annotation_dir, get_image_dir, NUM_THREADS
 
 
 class Yolo(FormatSpec):
@@ -110,27 +113,21 @@ class Yolo(FormatSpec):
             split = split if self._has_image_split else ""
             annotations = Path(self._annotation_dir).joinpath(split).glob("*.txt")
 
-            for txt in annotations:
-                stem = txt.stem
-                try:
-                    img_file = list(Path(self._image_dir).joinpath(split).glob(f"{stem}*"))[0]
-                    im_width, im_height = imagesize.get(img_file)
-                    with open(txt, "r") as f:
-                        instances = f.read().strip().split("\n")
-                        for ins in instances:
-                            class_id, x, y, w, h = list(map(float, ins.split()))
-                            image_ids.append(img_file.name)
-                            image_paths.append(img_file)
-                            class_ids.append(int(class_id))
-                            x_mins.append(max(float((float(x) - w / 2) * im_width), 0))
-                            y_mins.append(max(float((y - h / 2) * im_height), 0))
-                            bbox_widths.append(float(w * im_width))
-                            bbox_heights.append(float(h * im_height))
-                            image_widths.append(im_width)
-                            image_heights.append(im_height)
-
-                except IndexError:  # if the image file does not exist
-                    pass
+            parse_partial = partial(self._parse_txt_file, split)
+            print("Loading yolo annotations:")
+            all_instances = Parallel(n_jobs=NUM_THREADS, backend="threading")(
+                delayed(parse_partial)(txt) for txt in tqdm(annotations, desc=split)
+            )
+            for instances in all_instances:
+                image_ids.extend(instances["image_ids"])
+                image_paths.extend(instances["image_paths"])
+                class_ids.extend(instances["class_ids"])
+                x_mins.extend(instances["x_mins"])
+                y_mins.extend(instances["y_mins"])
+                bbox_widths.extend(instances["bbox_widths"])
+                bbox_heights.extend(instances["bbox_heights"])
+                image_widths.extend(instances["image_widths"])
+                image_heights.extend(instances["image_heights"])
 
             annots_df = pd.DataFrame(
                 list(
@@ -179,3 +176,47 @@ class Yolo(FormatSpec):
         else:
             master_df["category"] = master_df["class_id"].astype(str)
         self.master_df = master_df
+
+    def _parse_txt_file(self, split: str, txt: Union[str, os.PathLike]) -> Dict:
+        """Parse txt annotations in yolo format
+
+        Args:
+            split (str): dataset split
+            txt (Union[str, os.PathLike]): annotations file path
+
+        Returns:
+            Dict: dict containing scaled annotation for each line in the text file.
+        """
+        label_info_keys = [
+            "image_ids",
+            "image_paths",
+            "class_ids",
+            "x_mins",
+            "y_mins",
+            "bbox_widths",
+            "bbox_heights",
+            "image_heights",
+            "image_widths",
+        ]
+        label_info = {key: [] for key in label_info_keys}
+        stem = txt.stem
+        try:
+            img_file = list(Path(self._image_dir).joinpath(split).glob(f"{stem}*"))[0]
+            im_width, im_height = imagesize.get(img_file)
+        except IndexError:  # if the image file does not exist
+            return label_info
+
+        with open(txt, "r") as f:
+            instances = f.read().strip().split("\n")
+            for ins in instances:
+                class_id, x, y, w, h = list(map(float, ins.split()))
+                label_info["image_ids"].append(img_file.name)
+                label_info["image_paths"].append(img_file)
+                label_info["class_ids"].append(int(class_id))
+                label_info["x_mins"].append(max(float((float(x) - w / 2) * im_width), 0))
+                label_info["y_mins"].append(max(float((y - h / 2) * im_height), 0))
+                label_info["bbox_widths"].append(float(w * im_width))
+                label_info["bbox_heights"].append(float(h * im_height))
+                label_info["image_widths"].append(im_width)
+                label_info["image_heights"].append(im_height)
+        return label_info

--- a/optical/converter/yolo.py
+++ b/optical/converter/yolo.py
@@ -7,6 +7,7 @@ Created: Monday, 29th March 2021
 
 import os
 import warnings
+from functools import partial
 from pathlib import Path
 from typing import Dict, Union
 
@@ -14,12 +15,11 @@ import imagesize
 import numpy as np
 import pandas as pd
 import yaml
-from tqdm.auto import tqdm
 from joblib import Parallel, delayed
-from functools import partial
+from tqdm.auto import tqdm
 
 from .base import FormatSpec
-from .utils import exists, get_annotation_dir, get_image_dir, NUM_THREADS
+from .utils import NUM_THREADS, exists, get_annotation_dir, get_image_dir
 
 
 class Yolo(FormatSpec):

--- a/optical/converter/yolo.py
+++ b/optical/converter/yolo.py
@@ -98,7 +98,7 @@ class Yolo(FormatSpec):
                 "image_path",
             ],
         )
-
+        print("Loading yolo annotations:")
         for split in self._splits:
             image_ids = []
             image_paths = []
@@ -114,7 +114,6 @@ class Yolo(FormatSpec):
             annotations = Path(self._annotation_dir).joinpath(split).glob("*.txt")
 
             parse_partial = partial(self._parse_txt_file, split)
-            print("Loading yolo annotations:")
             all_instances = Parallel(n_jobs=NUM_THREADS, backend="multiprocessing")(
                 delayed(parse_partial)(txt) for txt in tqdm(annotations, desc=split)
             )

--- a/optical/converter/yolo.py
+++ b/optical/converter/yolo.py
@@ -115,7 +115,7 @@ class Yolo(FormatSpec):
 
             parse_partial = partial(self._parse_txt_file, split)
             print("Loading yolo annotations:")
-            all_instances = Parallel(n_jobs=NUM_THREADS, backend="threading")(
+            all_instances = Parallel(n_jobs=NUM_THREADS, backend="multiprocessing")(
                 delayed(parse_partial)(txt) for txt in tqdm(annotations, desc=split)
             )
             for instances in all_instances:

--- a/poetry.lock
+++ b/poetry.lock
@@ -359,19 +359,20 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "importlib-metadata"
-version = "4.0.0"
+version = "4.11.3"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 typing-extensions = {version = ">=3.6.4", markers = "python_version < \"3.8\""}
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
+perf = ["ipython"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "ipython"
@@ -1019,18 +1020,19 @@ python-versions = "*"
 
 [[package]]
 name = "sphinx"
-version = "3.5.4"
+version = "4.5.0"
 description = "Python documentation generator"
 category = "main"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 
 [package.dependencies]
 alabaster = ">=0.7,<0.8"
 babel = ">=1.3"
 colorama = {version = ">=0.3.5", markers = "sys_platform == \"win32\""}
-docutils = ">=0.12,<0.17"
+docutils = ">=0.14,<0.18"
 imagesize = "*"
+importlib-metadata = {version = ">=4.4", markers = "python_version < \"3.10\""}
 Jinja2 = ">=2.3"
 packaging = "*"
 Pygments = ">=2.0"
@@ -1038,19 +1040,19 @@ requests = ">=2.5.0"
 snowballstemmer = ">=1.1"
 sphinxcontrib-applehelp = "*"
 sphinxcontrib-devhelp = "*"
-sphinxcontrib-htmlhelp = "*"
+sphinxcontrib-htmlhelp = ">=2.0.0"
 sphinxcontrib-jsmath = "*"
 sphinxcontrib-qthelp = "*"
-sphinxcontrib-serializinghtml = "*"
+sphinxcontrib-serializinghtml = ">=1.1.5"
 
 [package.extras]
 docs = ["sphinxcontrib-websupport"]
-lint = ["flake8 (>=3.5.0)", "isort", "mypy (>=0.800)", "docutils-stubs"]
+lint = ["flake8 (>=3.5.0)", "isort", "mypy (>=0.931)", "docutils-stubs", "types-typed-ast", "types-requests"]
 test = ["pytest", "pytest-cov", "html5lib", "cython", "typed-ast"]
 
 [[package]]
 name = "sphinx-panels"
-version = "0.5.2"
+version = "0.6.0"
 description = "A sphinx extension for creating panels in a grid layout."
 category = "main"
 optional = false
@@ -1058,7 +1060,7 @@ python-versions = "*"
 
 [package.dependencies]
 docutils = "*"
-sphinx = ">=2,<4"
+sphinx = ">=2,<5"
 
 [package.extras]
 code_style = ["pre-commit (>=2.7.0,<2.8.0)"]
@@ -1107,11 +1109,11 @@ test = ["pytest"]
 
 [[package]]
 name = "sphinxcontrib-htmlhelp"
-version = "1.0.3"
+version = "2.0.0"
 description = "sphinxcontrib-htmlhelp is a sphinx extension which renders HTML help files"
 category = "main"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 
 [package.extras]
 lint = ["flake8", "mypy", "docutils-stubs"]
@@ -1142,7 +1144,7 @@ test = ["pytest"]
 
 [[package]]
 name = "sphinxcontrib-serializinghtml"
-version = "1.1.4"
+version = "1.1.5"
 description = "sphinxcontrib-serializinghtml is a sphinx extension which outputs \"serialized\" HTML files (json and pickle)."
 category = "main"
 optional = false
@@ -1401,7 +1403,7 @@ tensorflow = ["tensorflow-cpu"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.1"
-content-hash = "017a796587c21ecba00cfe5e60152833d3861fbd2264171073054393103f3ee4"
+content-hash = "4a824600c9759e84092b408776b3cf240d6b7a93b699473cc084afb372a4a08a"
 
 [metadata.files]
 absl-py = [
@@ -1654,8 +1656,8 @@ imagesize = [
     {file = "imagesize-1.2.0.tar.gz", hash = "sha256:b1f6b5a4eab1f73479a50fb79fcf729514a900c341d8503d62a62dbc4127a2b1"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.0.0-py3-none-any.whl", hash = "sha256:19192b88d959336bfa6bdaaaef99aeafec179eca19c47c804e555703ee5f07ef"},
-    {file = "importlib_metadata-4.0.0.tar.gz", hash = "sha256:2e881981c9748d7282b374b68e759c87745c25427b67ecf0cc67fb6637a1bff9"},
+    {file = "importlib_metadata-4.11.3-py3-none-any.whl", hash = "sha256:1208431ca90a8cca1a6b8af391bb53c1a2db74e5d1cef6ddced95d4b2062edc6"},
+    {file = "importlib_metadata-4.11.3.tar.gz", hash = "sha256:ea4c597ebf37142f827b8f39299579e31685c31d3a438b59f469406afd0f2539"},
 ]
 ipython = [
     {file = "ipython-7.22.0-py3-none-any.whl", hash = "sha256:c0ce02dfaa5f854809ab7413c601c4543846d9da81010258ecdab299b542d199"},
@@ -1703,14 +1705,18 @@ kiwisolver = [
     {file = "kiwisolver-1.3.1-cp37-cp37m-manylinux2014_ppc64le.whl", hash = "sha256:1e1bc12fb773a7b2ffdeb8380609f4f8064777877b2225dec3da711b421fda31"},
     {file = "kiwisolver-1.3.1-cp37-cp37m-win32.whl", hash = "sha256:72c99e39d005b793fb7d3d4e660aed6b6281b502e8c1eaf8ee8346023c8e03bc"},
     {file = "kiwisolver-1.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:8be8d84b7d4f2ba4ffff3665bcd0211318aa632395a1a41553250484a871d454"},
+    {file = "kiwisolver-1.3.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:24cc411232d14c8abafbd0dddb83e1a4f54d77770b53db72edcfe1d611b3bf11"},
     {file = "kiwisolver-1.3.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:31dfd2ac56edc0ff9ac295193eeaea1c0c923c0355bf948fbd99ed6018010b72"},
+    {file = "kiwisolver-1.3.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:ef6eefcf3944e75508cdfa513c06cf80bafd7d179e14c1334ebdca9ebb8c2c66"},
     {file = "kiwisolver-1.3.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:563c649cfdef27d081c84e72a03b48ea9408c16657500c312575ae9d9f7bc1c3"},
     {file = "kiwisolver-1.3.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:78751b33595f7f9511952e7e60ce858c6d64db2e062afb325985ddbd34b5c131"},
     {file = "kiwisolver-1.3.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:a357fd4f15ee49b4a98b44ec23a34a95f1e00292a139d6015c11f55774ef10de"},
     {file = "kiwisolver-1.3.1-cp38-cp38-manylinux2014_ppc64le.whl", hash = "sha256:5989db3b3b34b76c09253deeaf7fbc2707616f130e166996606c284395da3f18"},
     {file = "kiwisolver-1.3.1-cp38-cp38-win32.whl", hash = "sha256:c08e95114951dc2090c4a630c2385bef681cacf12636fb0241accdc6b303fd81"},
     {file = "kiwisolver-1.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:44a62e24d9b01ba94ae7a4a6c3fb215dc4af1dde817e7498d901e229aaf50e4e"},
+    {file = "kiwisolver-1.3.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:6d9d8d9b31aa8c2d80a690693aebd8b5e2b7a45ab065bb78f1609995d2c79240"},
     {file = "kiwisolver-1.3.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:50af681a36b2a1dee1d3c169ade9fdc59207d3c31e522519181e12f1b3ba7000"},
+    {file = "kiwisolver-1.3.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:792e69140828babe9649de583e1a03a0f2ff39918a71782c76b3c683a67c6dfd"},
     {file = "kiwisolver-1.3.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:a53d27d0c2a0ebd07e395e56a1fbdf75ffedc4a05943daf472af163413ce9598"},
     {file = "kiwisolver-1.3.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:834ee27348c4aefc20b479335fd422a2c69db55f7d9ab61721ac8cd83eb78882"},
     {file = "kiwisolver-1.3.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:5c3e6455341008a054cccee8c5d24481bcfe1acdbc9add30aa95798e95c65621"},
@@ -1720,6 +1726,7 @@ kiwisolver = [
     {file = "kiwisolver-1.3.1-pp36-pypy36_pp73-macosx_10_9_x86_64.whl", hash = "sha256:0cd53f403202159b44528498de18f9285b04482bab2a6fc3f5dd8dbb9352e30d"},
     {file = "kiwisolver-1.3.1-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:33449715e0101e4d34f64990352bce4095c8bf13bed1b390773fc0a7295967b3"},
     {file = "kiwisolver-1.3.1-pp36-pypy36_pp73-win32.whl", hash = "sha256:401a2e9afa8588589775fe34fc22d918ae839aaaf0c0e96441c0fdbce6d8ebe6"},
+    {file = "kiwisolver-1.3.1-pp37-pypy37_pp73-macosx_10_9_x86_64.whl", hash = "sha256:d6563ccd46b645e966b400bb8a95d3457ca6cf3bba1e908f9e0927901dfebeb1"},
     {file = "kiwisolver-1.3.1.tar.gz", hash = "sha256:950a199911a8d94683a6b10321f9345d5a3a8433ec58b217ace979e18f16e248"},
 ]
 lxml = [
@@ -1730,32 +1737,44 @@ lxml = [
     {file = "lxml-4.6.3-cp27-cp27m-win_amd64.whl", hash = "sha256:8157dadbb09a34a6bd95a50690595e1fa0af1a99445e2744110e3dca7831c4ee"},
     {file = "lxml-4.6.3-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:7728e05c35412ba36d3e9795ae8995e3c86958179c9770e65558ec3fdfd3724f"},
     {file = "lxml-4.6.3-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:4bff24dfeea62f2e56f5bab929b4428ae6caba2d1eea0c2d6eb618e30a71e6d4"},
+    {file = "lxml-4.6.3-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_24_i686.whl", hash = "sha256:64812391546a18896adaa86c77c59a4998f33c24788cadc35789e55b727a37f4"},
+    {file = "lxml-4.6.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:c1a40c06fd5ba37ad39caa0b3144eb3772e813b5fb5b084198a985431c2f1e8d"},
     {file = "lxml-4.6.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:74f7d8d439b18fa4c385f3f5dfd11144bb87c1da034a466c5b5577d23a1d9b51"},
     {file = "lxml-4.6.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:f90ba11136bfdd25cae3951af8da2e95121c9b9b93727b1b896e3fa105b2f586"},
+    {file = "lxml-4.6.3-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:4c61b3a0db43a1607d6264166b230438f85bfed02e8cff20c22e564d0faff354"},
+    {file = "lxml-4.6.3-cp35-cp35m-manylinux2014_x86_64.whl", hash = "sha256:5c8c163396cc0df3fd151b927e74f6e4acd67160d6c33304e805b84293351d16"},
     {file = "lxml-4.6.3-cp35-cp35m-win32.whl", hash = "sha256:f2380a6376dfa090227b663f9678150ef27543483055cc327555fb592c5967e2"},
     {file = "lxml-4.6.3-cp35-cp35m-win_amd64.whl", hash = "sha256:c4f05c5a7c49d2fb70223d0d5bcfbe474cf928310ac9fa6a7c6dddc831d0b1d4"},
     {file = "lxml-4.6.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:d2e35d7bf1c1ac8c538f88d26b396e73dd81440d59c1ef8522e1ea77b345ede4"},
     {file = "lxml-4.6.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:289e9ca1a9287f08daaf796d96e06cb2bc2958891d7911ac7cae1c5f9e1e0ee3"},
     {file = "lxml-4.6.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:bccbfc27563652de7dc9bdc595cb25e90b59c5f8e23e806ed0fd623755b6565d"},
+    {file = "lxml-4.6.3-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:d916d31fd85b2f78c76400d625076d9124de3e4bda8b016d25a050cc7d603f24"},
     {file = "lxml-4.6.3-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:820628b7b3135403540202e60551e741f9b6d3304371712521be939470b454ec"},
+    {file = "lxml-4.6.3-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:c47ff7e0a36d4efac9fd692cfa33fbd0636674c102e9e8d9b26e1b93a94e7617"},
     {file = "lxml-4.6.3-cp36-cp36m-win32.whl", hash = "sha256:5a0a14e264069c03e46f926be0d8919f4105c1623d620e7ec0e612a2e9bf1c04"},
     {file = "lxml-4.6.3-cp36-cp36m-win_amd64.whl", hash = "sha256:92e821e43ad382332eade6812e298dc9701c75fe289f2a2d39c7960b43d1e92a"},
     {file = "lxml-4.6.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:efd7a09678fd8b53117f6bae4fa3825e0a22b03ef0a932e070c0bdbb3a35e654"},
     {file = "lxml-4.6.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:efac139c3f0bf4f0939f9375af4b02c5ad83a622de52d6dfa8e438e8e01d0eb0"},
     {file = "lxml-4.6.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:0fbcf5565ac01dff87cbfc0ff323515c823081c5777a9fc7703ff58388c258c3"},
+    {file = "lxml-4.6.3-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:36108c73739985979bf302006527cf8a20515ce444ba916281d1c43938b8bb96"},
     {file = "lxml-4.6.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:122fba10466c7bd4178b07dba427aa516286b846b2cbd6f6169141917283aae2"},
+    {file = "lxml-4.6.3-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:cdaf11d2bd275bf391b5308f86731e5194a21af45fbaaaf1d9e8147b9160ea92"},
     {file = "lxml-4.6.3-cp37-cp37m-win32.whl", hash = "sha256:3439c71103ef0e904ea0a1901611863e51f50b5cd5e8654a151740fde5e1cade"},
     {file = "lxml-4.6.3-cp37-cp37m-win_amd64.whl", hash = "sha256:4289728b5e2000a4ad4ab8da6e1db2e093c63c08bdc0414799ee776a3f78da4b"},
     {file = "lxml-4.6.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b007cbb845b28db4fb8b6a5cdcbf65bacb16a8bd328b53cbc0698688a68e1caa"},
     {file = "lxml-4.6.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:76fa7b1362d19f8fbd3e75fe2fb7c79359b0af8747e6f7141c338f0bee2f871a"},
     {file = "lxml-4.6.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:26e761ab5b07adf5f555ee82fb4bfc35bf93750499c6c7614bd64d12aaa67927"},
+    {file = "lxml-4.6.3-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:e1cbd3f19a61e27e011e02f9600837b921ac661f0c40560eefb366e4e4fb275e"},
     {file = "lxml-4.6.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:66e575c62792c3f9ca47cb8b6fab9e35bab91360c783d1606f758761810c9791"},
+    {file = "lxml-4.6.3-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:1b38116b6e628118dea5b2186ee6820ab138dbb1e24a13e478490c7db2f326ae"},
     {file = "lxml-4.6.3-cp38-cp38-win32.whl", hash = "sha256:89b8b22a5ff72d89d48d0e62abb14340d9e99fd637d046c27b8b257a01ffbe28"},
     {file = "lxml-4.6.3-cp38-cp38-win_amd64.whl", hash = "sha256:2a9d50e69aac3ebee695424f7dbd7b8c6d6eb7de2a2eb6b0f6c7db6aa41e02b7"},
     {file = "lxml-4.6.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ce256aaa50f6cc9a649c51be3cd4ff142d67295bfc4f490c9134d0f9f6d58ef0"},
     {file = "lxml-4.6.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:7610b8c31688f0b1be0ef882889817939490a36d0ee880ea562a4e1399c447a1"},
     {file = "lxml-4.6.3-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:f8380c03e45cf09f8557bdaa41e1fa7c81f3ae22828e1db470ab2a6c96d8bc23"},
+    {file = "lxml-4.6.3-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:3082c518be8e97324390614dacd041bb1358c882d77108ca1957ba47738d9d59"},
     {file = "lxml-4.6.3-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:884ab9b29feaca361f7f88d811b1eea9bfca36cf3da27768d28ad45c3ee6f969"},
+    {file = "lxml-4.6.3-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:6f12e1427285008fd32a6025e38e977d44d6382cf28e7201ed10d6c1698d2a9a"},
     {file = "lxml-4.6.3-cp39-cp39-win32.whl", hash = "sha256:33bb934a044cf32157c12bfcfbb6649807da20aa92c062ef51903415c704704f"},
     {file = "lxml-4.6.3-cp39-cp39-win_amd64.whl", hash = "sha256:542d454665a3e277f76954418124d67516c5f88e51a900365ed54a9806122b83"},
     {file = "lxml-4.6.3.tar.gz", hash = "sha256:39b78571b3b30645ac77b95f7c69d1bffc4cf8c3b157c435a34da72e78c82468"},
@@ -1997,6 +2016,7 @@ pillow = [
     {file = "Pillow-8.2.0-pp37-pypy37_pp73-manylinux2010_i686.whl", hash = "sha256:aac00e4bc94d1b7813fe882c28990c1bc2f9d0e1aa765a5f2b516e8a6a16a9e4"},
     {file = "Pillow-8.2.0-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:22fd0f42ad15dfdde6c581347eaa4adb9a6fc4b865f90b23378aa7914895e120"},
     {file = "Pillow-8.2.0-pp37-pypy37_pp73-win32.whl", hash = "sha256:e98eca29a05913e82177b3ba3d198b1728e164869c613d76d0de4bde6768a50e"},
+    {file = "Pillow-8.2.0-pp37-pypy37_pp73-win_amd64.whl", hash = "sha256:8b56553c0345ad6dcb2e9b433ae47d67f95fc23fe28a0bde15a120f25257e291"},
     {file = "Pillow-8.2.0.tar.gz", hash = "sha256:a787ab10d7bb5494e5f76536ac460741788f1fbce851068d73a87ca7c35fc3e1"},
 ]
 pluggy = [
@@ -2263,12 +2283,12 @@ snowballstemmer = [
     {file = "snowballstemmer-2.1.0.tar.gz", hash = "sha256:e997baa4f2e9139951b6f4c631bad912dfd3c792467e2f03d7239464af90e914"},
 ]
 sphinx = [
-    {file = "Sphinx-3.5.4-py3-none-any.whl", hash = "sha256:2320d4e994a191f4b4be27da514e46b3d6b420f2ff895d064f52415d342461e8"},
-    {file = "Sphinx-3.5.4.tar.gz", hash = "sha256:19010b7b9fa0dc7756a6e105b2aacd3a80f798af3c25c273be64d7beeb482cb1"},
+    {file = "Sphinx-4.5.0-py3-none-any.whl", hash = "sha256:ebf612653238bcc8f4359627a9b7ce44ede6fdd75d9d30f68255c7383d3a6226"},
+    {file = "Sphinx-4.5.0.tar.gz", hash = "sha256:7bf8ca9637a4ee15af412d1a1d9689fec70523a68ca9bb9127c2f3eeb344e2e6"},
 ]
 sphinx-panels = [
-    {file = "sphinx-panels-0.5.2.tar.gz", hash = "sha256:b7b3faa05f37b7318fd14cd85c4effa1ab905dfc8bed236a63978565ea461ae4"},
-    {file = "sphinx_panels-0.5.2-py3-none-any.whl", hash = "sha256:2b2e18448b0494e7a232d6c7dfb9aa3982e7aeb92aeea7d1b146e34e9261d2f1"},
+    {file = "sphinx-panels-0.6.0.tar.gz", hash = "sha256:d36dcd26358117e11888f7143db4ac2301ebe90873ac00627bf1fe526bf0f058"},
+    {file = "sphinx_panels-0.6.0-py3-none-any.whl", hash = "sha256:bd64afaf85c07f8096d21c8247fc6fd757e339d1be97832c8832d6ae5ed2e61d"},
 ]
 sphinx-rtd-theme = [
     {file = "sphinx_rtd_theme-0.5.2-py2.py3-none-any.whl", hash = "sha256:4a05bdbe8b1446d77a01e20a23ebc6777c74f43237035e76be89699308987d6f"},
@@ -2283,8 +2303,8 @@ sphinxcontrib-devhelp = [
     {file = "sphinxcontrib_devhelp-1.0.2-py2.py3-none-any.whl", hash = "sha256:8165223f9a335cc1af7ffe1ed31d2871f325254c0423bc0c4c7cd1c1e4734a2e"},
 ]
 sphinxcontrib-htmlhelp = [
-    {file = "sphinxcontrib-htmlhelp-1.0.3.tar.gz", hash = "sha256:e8f5bb7e31b2dbb25b9cc435c8ab7a79787ebf7f906155729338f3156d93659b"},
-    {file = "sphinxcontrib_htmlhelp-1.0.3-py2.py3-none-any.whl", hash = "sha256:3c0bc24a2c41e340ac37c85ced6dafc879ab485c095b1d65d2461ac2f7cca86f"},
+    {file = "sphinxcontrib-htmlhelp-2.0.0.tar.gz", hash = "sha256:f5f8bb2d0d629f398bf47d0d69c07bc13b65f75a81ad9e2f71a63d4b7a2f6db2"},
+    {file = "sphinxcontrib_htmlhelp-2.0.0-py2.py3-none-any.whl", hash = "sha256:d412243dfb797ae3ec2b59eca0e52dac12e75a241bf0e4eb861e450d06c6ed07"},
 ]
 sphinxcontrib-jsmath = [
     {file = "sphinxcontrib-jsmath-1.0.1.tar.gz", hash = "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"},
@@ -2295,8 +2315,8 @@ sphinxcontrib-qthelp = [
     {file = "sphinxcontrib_qthelp-1.0.3-py2.py3-none-any.whl", hash = "sha256:bd9fc24bcb748a8d51fd4ecaade681350aa63009a347a8c14e637895444dfab6"},
 ]
 sphinxcontrib-serializinghtml = [
-    {file = "sphinxcontrib-serializinghtml-1.1.4.tar.gz", hash = "sha256:eaa0eccc86e982a9b939b2b82d12cc5d013385ba5eadcc7e4fed23f4405f77bc"},
-    {file = "sphinxcontrib_serializinghtml-1.1.4-py2.py3-none-any.whl", hash = "sha256:f242a81d423f59617a8e5cf16f5d4d74e28ee9a66f9e5b637a18082991db5a9a"},
+    {file = "sphinxcontrib-serializinghtml-1.1.5.tar.gz", hash = "sha256:aa5f6de5dfdf809ef505c4895e51ef5c9eac17d0f287933eb49ec495280b6952"},
+    {file = "sphinxcontrib_serializinghtml-1.1.5-py2.py3-none-any.whl", hash = "sha256:352a9a00ae864471d3a7ead8d7d79f5fc0b57e8b3f95e9867eb9eb28999b92fd"},
 ]
 tensorboard = [
     {file = "tensorboard-2.4.1-py3-none-any.whl", hash = "sha256:7b8c53c396069b618f6f276ec94fc45d17e3282d668979216e5d30be472115e4"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ version = "0.0.2"
 [tool.poetry.dependencies]
 Pillow = "^8.2.0"
 PyYAML = "^5.4.1"
-Sphinx = {version = "^3.5.3", optional = true}
+Sphinx = "4.5.0"
 altair = "^4.1.0"
 bounding-box = "^0.1.3"
 imagesize = "^1.2.0"
@@ -42,19 +42,19 @@ pandas = "^1.2.3"
 python = "^3.7.1"
 scikit-learn = "^0.24.1"
 scikit-multilearn = "^0.2.0"
-sphinx-panels = {version = "^0.5.2", optional = true}
+sphinx-panels = {version = "^0.6.0", optional = true}
 sphinx-rtd-theme = {version = "^0.5.1", optional = true}
 tensorflow-cpu = {version = "^2.4.1", optional = true}
 tqdm = "^4.59.0"
 
 [tool.poetry.dev-dependencies]
-Sphinx = "^3.5.3"
+Sphinx = "^4.5.0"
 black = "^20.8b1"
 flake8 = "^3.9.0"
 kaggle = "^1.5.12"
 pytest = "^5.2"
 pytest-cov = "^2.11.1"
-sphinx-panels = "^0.5.2"
+sphinx-panels = "^0.6.0"
 sphinx-rtd-theme = "^0.5.1"
 tox = "^3.23.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ version = "0.0.2"
 [tool.poetry.dependencies]
 Pillow = "^8.2.0"
 PyYAML = "^5.4.1"
-Sphinx = {version = "^3.5.3", optional = true}
+Sphinx = {version = "^4.5.0", optional = true}
 altair = "^4.1.0"
 bounding-box = "^0.1.3"
 imagesize = "^1.2.0"
@@ -42,19 +42,19 @@ pandas = "^1.2.3"
 python = "^3.7.1"
 scikit-learn = "^0.24.1"
 scikit-multilearn = "^0.2.0"
-sphinx-panels = {version = "^0.5.2", optional = true}
+sphinx-panels = {version = "^0.6.0", optional = true}
 sphinx-rtd-theme = {version = "^0.5.1", optional = true}
 tensorflow-cpu = {version = "^2.4.1", optional = true}
 tqdm = "^4.59.0"
 
 [tool.poetry.dev-dependencies]
-Sphinx = "^3.5.3"
+Sphinx = "^4.5.0"
 black = "^20.8b1"
 flake8 = "^3.9.0"
 kaggle = "^1.5.12"
 pytest = "^5.2"
 pytest-cov = "^2.11.1"
-sphinx-panels = "^0.5.2"
+sphinx-panels = "^0.6.0"
 sphinx-rtd-theme = "^0.5.1"
 tox = "^3.23.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ version = "0.0.2"
 [tool.poetry.dependencies]
 Pillow = "^8.2.0"
 PyYAML = "^5.4.1"
-Sphinx = {version = "^4.5.0", optional = true}
+Sphinx = {version = "^3.5.3", optional = true}
 altair = "^4.1.0"
 bounding-box = "^0.1.3"
 imagesize = "^1.2.0"
@@ -42,19 +42,19 @@ pandas = "^1.2.3"
 python = "^3.7.1"
 scikit-learn = "^0.24.1"
 scikit-multilearn = "^0.2.0"
-sphinx-panels = {version = "^0.6.0", optional = true}
+sphinx-panels = {version = "^0.5.2", optional = true}
 sphinx-rtd-theme = {version = "^0.5.1", optional = true}
 tensorflow-cpu = {version = "^2.4.1", optional = true}
 tqdm = "^4.59.0"
 
 [tool.poetry.dev-dependencies]
-Sphinx = "^4.5.0"
+Sphinx = "^3.5.3"
 black = "^20.8b1"
 flake8 = "^3.9.0"
 kaggle = "^1.5.12"
 pytest = "^5.2"
 pytest-cov = "^2.11.1"
-sphinx-panels = "^0.6.0"
+sphinx-panels = "^0.5.2"
 sphinx-rtd-theme = "^0.5.1"
 tox = "^3.23.0"
 


### PR DESCRIPTION
Currently, loading  yolo dataset(~150k) is taking prohibitively long time compared to loading the same dataset in coco format.

I think it is mostly because of yolo annotation format where we don't have actual image width and heights. So we are trying to get the height and width of the images using `imagesize.get`  but required while converting to other formats.

Nothing much, just parallelized for loop using `joblib.Parallel` using half the available threads by default. Also updated copyright year in the docs.

Speed test on ~150k dataset:
before `joblib.Parallel` : >180 mins
after `joblib.Parallel`: ~12 mins